### PR TITLE
Fix: Rendition change event issue

### DIFF
--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -342,6 +342,10 @@ public class MUXSDKPlayerBinding: NSObject {
         let currentVideoIsLive = player.isLive()
         let liveUpdates = videoData.isLive != currentVideoIsLive
         
+        if self.videoData.lastDispatchedAdvertisedBitrate != self.videoData.lastAdvertisedBitrate {
+            self.videoData.hasUpdates = true
+        }
+        
         let videoDataUpdated = videoData.hasUpdates || liveUpdates
 
         if self.videoData.sourceDimensionsHaveChanged, self.videoData.size.equalTo(self.videoData.lastDispatchedVideoSize) {
@@ -378,11 +382,6 @@ public class MUXSDKPlayerBinding: NSObject {
         
         if (self.videoData.lastAdvertisedBitrate > 0 && self.videoData.started) {
             eventVideoData.videoSourceAdvertisedBitrate = NSNumber(value: self.videoData.lastAdvertisedBitrate)
-            
-            if self.videoData.lastDispatchedAdvertisedBitrate != self.videoData.lastAdvertisedBitrate {
-                self.videoData.hasUpdates = true
-            }
-            
             self.videoData.lastDispatchedAdvertisedBitrate = self.videoData.lastAdvertisedBitrate
         }
         
@@ -414,7 +413,6 @@ public class MUXSDKPlayerBinding: NSObject {
         }
         
         self.videoData.sourceDimensionsHaveChanged = true
-        self.videoData.hasUpdates = true
         self.dispatchRenditionChange()
     }
     

--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -378,6 +378,11 @@ public class MUXSDKPlayerBinding: NSObject {
         
         if (self.videoData.lastAdvertisedBitrate > 0 && self.videoData.started) {
             eventVideoData.videoSourceAdvertisedBitrate = NSNumber(value: self.videoData.lastAdvertisedBitrate)
+            
+            if self.videoData.lastDispatchedAdvertisedBitrate != self.videoData.lastAdvertisedBitrate {
+                self.videoData.hasUpdates = true
+            }
+            
             self.videoData.lastDispatchedAdvertisedBitrate = self.videoData.lastAdvertisedBitrate
         }
         
@@ -393,7 +398,6 @@ public class MUXSDKPlayerBinding: NSObject {
             self.videoData.lastAdvertisedBitrate != 0,
             self.videoData.started
         else {
-            self.videoData.hasUpdates = true
             self.videoData.lastAdvertisedBitrate = event.indicatedBitrate
             return
         }

--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -341,12 +341,9 @@ public class MUXSDKPlayerBinding: NSObject {
     private func updateVideoData(player: Player) {
         let currentVideoIsLive = player.isLive()
         let liveUpdates = videoData.isLive != currentVideoIsLive
+        let renditionUpdates = self.videoData.lastDispatchedAdvertisedBitrate != self.videoData.lastAdvertisedBitrate
         
-        if self.videoData.lastDispatchedAdvertisedBitrate != self.videoData.lastAdvertisedBitrate {
-            self.videoData.hasUpdates = true
-        }
-        
-        let videoDataUpdated = videoData.hasUpdates || liveUpdates
+        let videoDataUpdated = videoData.hasUpdates || liveUpdates || renditionUpdates
 
         if self.videoData.sourceDimensionsHaveChanged, self.videoData.size.equalTo(self.videoData.lastDispatchedVideoSize) {
             let sourceDimensions = player.sourceDimensions

--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -400,11 +400,13 @@ public class MUXSDKPlayerBinding: NSObject {
     private func handleRenditionChange(bitrate: Double, playbackStartDate: Date?) {
         guard
             self.videoData.lastAdvertisedBitrate != 0,
-            playbackStartDate != nil
+            self.videoData.started
         else {
             self.videoData.lastAdvertisedBitrate = bitrate
             return
         }
+        
+        guard playbackStartDate != nil else { return }
         print("MUXSDK-INFO - Switch advertised bitrate from: \(self.videoData.lastAdvertisedBitrate) to: \(bitrate)")
         self.videoData.lastAdvertisedBitrate = bitrate
         guard self.videoData.lastDispatchedAdvertisedBitrate != self.videoData.lastAdvertisedBitrate else {

--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -665,7 +665,10 @@ extension MUXSDKPlayerBinding {
     }
     
     private func dispatchRenditionChange() {
-        guard let player = self.player else {
+        guard
+            let player = self.player,
+            self.videoData.started
+        else {
             print("MUXSDK-ERROR - Mux failed to find the Kaltura Playkit Player for player name: \(self.name)")
             return
         }

--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -460,7 +460,7 @@ public class MUXSDKPlayerBinding: NSObject {
         return host ?? urlString
     }
     
-    @objc func handleAccessLogEntry(notification: Notification) {
+    @objc private func handleAccessLogEntry(notification: Notification) {
         guard
             let playerItem = notification.object as? AVPlayerItem,
             playerItem == self.player?.currentItem, // Confirm notification is relevant to current player item

--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -376,7 +376,7 @@ public class MUXSDKPlayerBinding: NSObject {
         
         eventVideoData.videoSourceUrl = videoData.url
         
-        if (self.videoData.lastAdvertisedBitrate > 0) {
+        if (self.videoData.lastAdvertisedBitrate > 0 && self.videoData.started) {
             eventVideoData.videoSourceAdvertisedBitrate = NSNumber(value: self.videoData.lastAdvertisedBitrate)
             self.videoData.lastDispatchedAdvertisedBitrate = self.videoData.lastAdvertisedBitrate
         }
@@ -393,6 +393,7 @@ public class MUXSDKPlayerBinding: NSObject {
             self.videoData.lastAdvertisedBitrate != 0,
             self.videoData.started
         else {
+            self.videoData.hasUpdates = true
             self.videoData.lastAdvertisedBitrate = event.indicatedBitrate
             return
         }


### PR DESCRIPTION
Used access logs to get `playbackStartDate` from last event to dispatch `renditionChangeEvent`

Mux Dashboard logs for an example forcing rendition change events with network link conditioner: https://dashboard.mux.com/organizations/rsrve1/environments/84hqkt/views/9AJqlB2FVeGeBJtZMeUA8AFBNgTEK1nN8d1n