### PR TITLE
Fix: Missing play event

### DIFF
--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -603,7 +603,7 @@ extension MUXSDKPlayerBinding {
             return
         }
         
-        guard self.state != .playing else {
+        guard self.state == .playing else {
             return
         }
         


### PR DESCRIPTION
Missing play event was caused by the events not being submitted frequently and missing timeUpdateEvents.
The solution was to fix the missing timeUpdateEvents (`heartbeatEvents`) for flushing the events more frequently and avoid big time gaps between `startViewEvent` and `playEvent`