### PR TITLE
Releases/v2.2.0

### DIFF
--- a/MUXSDKKaltura/MUXSDKKaltura.xcodeproj/project.pbxproj
+++ b/MUXSDKKaltura/MUXSDKKaltura.xcodeproj/project.pbxproj
@@ -669,10 +669,10 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = MUXSDKKaltura/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.ios.MUXSDKKaltura;
@@ -710,10 +710,10 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = MUXSDKKaltura/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 2.0.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.ios.MUXSDKKaltura;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -742,7 +742,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = MUXSDKKalturaTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -771,7 +771,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = MUXSDKKalturaTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
@@ -808,7 +808,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.tvos.MUXSDKKalturaTv;
@@ -818,7 +818,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -848,7 +848,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 2.0.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.tvos.MUXSDKKalturaTv;
 				PRODUCT_NAME = MUXSDKKaltura;
@@ -856,7 +856,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
+++ b/MUXSDKKaltura/MUXSDKKaltura/MUXSDKPlayerBinding.swift
@@ -749,7 +749,9 @@ extension MUXSDKPlayerBinding {
         
         self.updateVideoData(player: player)
         
-        let event = MUXSDKErrorEvent()
+        guard let event = MUXSDKErrorEvent() else {
+            return
+        }
         event.playerData = self.playerData
         self.dispatcher.dispatchEvent(event, forPlayer: self.name)
         
@@ -767,7 +769,9 @@ extension MUXSDKPlayerBinding {
         playerData.playerErrorCode = code
         playerData.playerErrorMessage = message
         
-        let event = MUXSDKErrorEvent()
+        guard let event = MUXSDKErrorEvent() else {
+            return
+        }
         event.playerData = playerData
         self.dispatcher.dispatchEvent(event, forPlayer: self.name)
         

--- a/MUXSDKKaltura/Podfile
+++ b/MUXSDKKaltura/Podfile
@@ -4,13 +4,13 @@ target 'MUXSDKKaltura' do
   use_frameworks!
   
   # Pods for MUXSDKKaltura
-  pod 'Mux-Stats-Core', '~>3.11'
+  pod 'Mux-Stats-Core', '~>4.4'
   pod 'PlayKit'
 
   target 'MUXSDKKalturaTests' do
     inherit! :search_paths
     # Pods for testing
-    pod 'Mux-Stats-Core', '~>3.11'
+    pod 'Mux-Stats-Core', '~>4.4'
     pod 'PlayKit'
   end
 end
@@ -20,14 +20,14 @@ target 'MUXSDKKalturaTv' do
   use_frameworks!
   
   # Pods for MUXSDKKalturaTv
-  pod 'Mux-Stats-Core', '~>3.11'
+  pod 'Mux-Stats-Core', '~>4.4'
   pod 'PlayKit'
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '9.0'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
     end
   end
 end

--- a/MUXSDKKaltura/Podfile.lock
+++ b/MUXSDKKaltura/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
-  - KalturaNetKit (1.5.1):
-    - KalturaNetKit/Core (= 1.5.1)
-  - KalturaNetKit/Core (1.5.1):
+  - KalturaNetKit (1.6.1):
+    - KalturaNetKit/Core (= 1.6.1)
+  - KalturaNetKit/Core (1.6.1):
     - SwiftyJSON (= 5.0.0)
-  - Mux-Stats-Core (3.11.0)
+  - Mux-Stats-Core (4.4.0)
   - ObjcExceptionBridging (1.0.1):
     - ObjcExceptionBridging/ObjcExceptionBridging (= 1.0.1)
   - ObjcExceptionBridging/ObjcExceptionBridging (1.0.1)
-  - PlayKit (3.24.0):
-    - PlayKit/Core (= 3.24.0)
-  - PlayKit/Core (3.24.0):
-    - KalturaNetKit (~> 1.5.1)
+  - PlayKit (3.27.2):
+    - PlayKit/Core (= 3.27.2)
+  - PlayKit/Core (3.27.2):
+    - KalturaNetKit (~> 1.6.1)
     - PlayKitUtils (~> 0.5)
     - SwiftyJSON (= 5.0.0)
     - XCGLogger (= 7.0.0)
-  - PlayKitUtils (0.5.0)
+  - PlayKitUtils (0.5.1)
   - SwiftyJSON (5.0.0)
   - XCGLogger (7.0.0):
     - XCGLogger/Core (= 7.0.0)
@@ -22,7 +22,7 @@ PODS:
     - ObjcExceptionBridging
 
 DEPENDENCIES:
-  - Mux-Stats-Core (~> 3.11)
+  - Mux-Stats-Core (~> 4.4)
   - PlayKit
 
 SPEC REPOS:
@@ -36,14 +36,14 @@ SPEC REPOS:
     - XCGLogger
 
 SPEC CHECKSUMS:
-  KalturaNetKit: 8774fdc2e73d3d013c3df88aa49376dd922d3606
-  Mux-Stats-Core: 0415ae94508651e151f0e82e2d954955059d5b67
+  KalturaNetKit: 2af6c3c2a1abbd8936b5acde45f33f5195125f4a
+  Mux-Stats-Core: 27b28bc277a891190753869600c5e01e2188125c
   ObjcExceptionBridging: c30e00eb3700467e695faeea30e26e18bd445001
-  PlayKit: ccb50808c5ddbf416d309b42a000b9086ef69149
-  PlayKitUtils: 8edb43515c8b91d9aa9a47ae8b5af1e7dd58f6f3
+  PlayKit: 4e2c81a6495b2266cc523f767e6e36eb78305ac0
+  PlayKitUtils: 4a11aef6488e778d10b774702ba79dd0cfa0ef11
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   XCGLogger: 0434f15e3909cdc450bb63faf638b8792ab782ab
 
-PODFILE CHECKSUM: 215a86154dc25a62f75422c81d4fc489bcf4bc2a
+PODFILE CHECKSUM: 484d3a528a1458962b24884e1c50eb15538f686e
 
 COCOAPODS: 1.11.3

--- a/Mux-Stats-Kaltura.podspec
+++ b/Mux-Stats-Kaltura.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Mux-Stats-Kaltura'
 
-  s.version          = '1.2.0'
+  s.version          = '2.0.0'
   s.source           = { :git => 'https://github.com/muxinc/mux-stats-sdk-kaltura.git',
                          :tag => "v#{s.version}" }
 
@@ -15,15 +15,15 @@ Pod::Spec.new do |s|
   s.author           = { 'Mux' => 'ios-sdk@mux.com' }
   s.swift_version = '5.0'
 
-  s.dependency 'Mux-Stats-Core', '~>3.11'
+  s.dependency 'Mux-Stats-Core', '~>4.4'
   s.dependency 'PlayKit', '~>3.21'
 
   s.frameworks = 'AVFoundation', 'Network', 'SystemConfiguration'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   s.ios.vendored_frameworks = 'XCFramework/MUXSDKKaltura.xcframework'
 
-  s.tvos.deployment_target = '9.0'
+  s.tvos.deployment_target = '11.0'
   s.tvos.vendored_frameworks = 'XCFramework/MUXSDKKaltura.xcframework'
 
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Fixes

* Update MuxCore dependency and rebuild with recent tools. Some linkage changes have been necessary, but you shouldn't see any issues. You may require XCode 14 to use this version of the Data SDK for Kaltura